### PR TITLE
fix: Fix test compatibility with bleak>=0.20.0

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,7 @@ DBUS_ERROR_IN_PROGRESS = BleakDBusError("org.bluez.Error.InProgress", [])
 
 @pytest.fixture()
 def mock_client() -> Generator[MockSnoozClient, None, None]:
-    yield MockSnoozClient(BLEDevice("Snooz-ABCD", "00:00:00:00:12:34"))
+    yield MockSnoozClient(BLEDevice("Snooz-ABCD", "00:00:00:00:12:34", [], 0))
 
 
 @pytest.fixture()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -94,7 +94,7 @@ class SnoozTestFixture:
 
 @pytest.fixture(scope="function")
 def snooz(mocker: MockerFixture, event_loop: AbstractEventLoop) -> SnoozTestFixture:
-    device = BLEDevice("AA:BB:CC:DD:EE:FF", "Snooz-EEFF")
+    device = BLEDevice("AA:BB:CC:DD:EE:FF", "Snooz-EEFF", [], 0)
     token = "AABBCCDDEEFF"
 
     def get_connected_client(


### PR DESCRIPTION
With the bleak 0.20.0 release the rssi and metadata attributes on the BLEDevice object became properties, that need to be initialized in the constructor. This broke parts of the test suite, that this changeset fixes.

https://github.com/hbldh/bleak/releases/tag/v0.20.0
https://github.com/hbldh/bleak/pull/1059

Closes: #8